### PR TITLE
Update config.py: clientSeed string -> bytes

### DIFF
--- a/app/helpers/config.py
+++ b/app/helpers/config.py
@@ -112,7 +112,7 @@ class Abi:
                         {"internalType": "uint256", "name": "taskFee", "type": "uint256"},
                         {"internalType": "bytes32", "name": "seed", "type": "bytes32"},
                         {"internalType": "bytes32", "name": "result", "type": "bytes32"},
-                        {"internalType": "string", "name": "clientSeed", "type": "string"},
+                        {"internalType": "bytes", "name": "clientSeed", "type": "bytes"},
                     ],
                     "internalType": "struct VRFLensV2.Task[]",
                     "name": "",


### PR DESCRIPTION
The clientSeed may not always be decoded into a string because arbitrary bytes can be sent as a string inside Solidity, but it will be an error when external services try to decode such bytes into a string.
For an example:
 - `string public constant S = string(abi.encode(keccak256(abi.encode(1,2,3,4))));`
Although this is valid in Solidity, it can't be decoded into a readable (utf-8, ascii, ...) string ( 9'��bz&OS��eթ:2�qߝ�F�߂�-) and might cause an error.